### PR TITLE
9 host the static client when running server in production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ Thumbs.db
 # Next.js
 .next
 out
+
+apps/server/src/client

--- a/apps/client/webpack.config.js
+++ b/apps/client/webpack.config.js
@@ -4,7 +4,7 @@ const { join } = require('path');
 
 module.exports = {
   output: {
-    path: join(__dirname, '../../dist/apps/client')
+    path: join(__dirname, '../server/src/client')
   },
   devServer: {
     port: 4200

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -3,6 +3,9 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "apps/server/src",
   "projectType": "application",
+  "implicitDependencies": [
+    "client"
+  ],
   "tags": [],
   "targets": {
     "serve": {

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -1,9 +1,18 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { join } from 'path';
 import { AppModule } from './app/app.module';
 
 export const bootstrap = async () => {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  // @note: debug only, not prod ready
+  app.useStaticAssets(join(__dirname, '..', '..', '..', 'dist', 'apps', 'client'));
+
+  // @note: this adds support for controller views using handlebars templates in views folder
+  // app.setBaseViewsDir('views');
+  // app.setViewEngine('hbs');
 
   const port = process.env.PORT || 3000;
   await app.listen(port);

--- a/apps/server/src/bootstrap.ts
+++ b/apps/server/src/bootstrap.ts
@@ -1,16 +1,13 @@
 import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
-import { join } from 'path';
 import { AppModule } from './app/app.module';
 
 export const bootstrap = async () => {
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 
-  // @note: debug only, not prod ready
-  app.useStaticAssets(join(__dirname, '..', '..', '..', 'dist', 'apps', 'client'));
+  app.useStaticAssets('client');
 
-  // @note: this adds support for controller views using handlebars templates in views folder
   // app.setBaseViewsDir('views');
   // app.setViewEngine('hbs');
 

--- a/apps/server/webpack.config.js
+++ b/apps/server/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
       compiler: 'tsc',
       main: './src/main.ts',
       tsConfig: './tsconfig.app.json',
-      assets: ['./src/assets'],
+      assets: ['./src/client'],
       optimization: false,
       outputHashing: 'none'
     })


### PR DESCRIPTION
- feat(bootstrap.ts): add static assets support for serving client app refactor(bootstrap.ts): use NestExpressApplication for enhanced express features
- chore(project.json): add implicit dependency on client to ensure proper build order
- refactor(client): change output path in webpack config to align with server structure refactor(server): simplify static assets path in bootstrap for better maintainability fix(server): update webpack config to include client assets for consistent build output
