### PR TITLE
Update GitHub Actions workflow for website deployment

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,15 +21,8 @@ env:
   NX: node_modules/.bin/nx
 
 jobs:
-  # @note: Website has no dependencies, but maybe later it will.
-  #  build:
-  #    uses: ./.github/workflows/build.yml
-  #    with:
-  #      testOnly: true
-
-  artifacts:
+  build:
     runs-on: ubuntu-latest
-    needs: [ build ]
     steps:
       - name: "📥 Checkout code"
         uses: actions/checkout@v4
@@ -65,7 +58,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    needs: [ artifacts ]
+    needs: [ build ]
     if: ${{ github.event.inputs.skipDeploy == 'false' }}
     steps:
       - name: "🚀 Deploy to GitHub Pages"


### PR DESCRIPTION
The GitHub Actions workflow for deploying the static website to GitHub Pages has been updated. The unnecessary artifacts job has been removed, and the build job has been renamed to `build` and updated with the necessary steps for building the website. The deployment job has also been updated to have a dependency on the `build` job.